### PR TITLE
Houghtonap patch 1

### DIFF
--- a/Engine/Source/NDMarkup/Iterator.cs
+++ b/Engine/Source/NDMarkup/Iterator.cs
@@ -46,7 +46,7 @@ namespace CodeClear.NaturalDocs.Engine.NDMarkup
 				BulletListTag, BulletListItemTag,
 				DefinitionListTag, DefinitionListEntryTag, DefinitionListSymbolTag, DefinitionListDefinitionTag,
 
-				BoldTag, ItalicsTag, UnderlineTag,
+				BoldTag, ItalicsTag, UnderlineTag, CodeTag,
 				LinkTag,
 
 			HighestTagValue
@@ -79,6 +79,7 @@ namespace CodeClear.NaturalDocs.Engine.NDMarkup
 			TagNameToElementType.Add("b", ElementType.BoldTag);
 			TagNameToElementType.Add("i", ElementType.ItalicsTag);
 			TagNameToElementType.Add("u", ElementType.UnderlineTag);
+            TagNameToElementType.Add("code", ElementType.CodeTag);
 			TagNameToElementType.Add("link", ElementType.LinkTag);
 
 			EntityCharToElementType = new Collections.StringTable<ElementType>();

--- a/Engine/Source/Output/Components/HTMLTopic.cs
+++ b/Engine/Source/Output/Components/HTMLTopic.cs
@@ -259,6 +259,7 @@ namespace CodeClear.NaturalDocs.Engine.Output.Components
 					case NDMarkup.Iterator.ElementType.BoldTag:
 					case NDMarkup.Iterator.ElementType.ItalicsTag:
 					case NDMarkup.Iterator.ElementType.UnderlineTag:
+                    case NDMarkup.Iterator.ElementType.CodeTag:
 					case NDMarkup.Iterator.ElementType.LTEntityChar:
 					case NDMarkup.Iterator.ElementType.GTEntityChar:
 					case NDMarkup.Iterator.ElementType.AmpEntityChar:

--- a/NaturalDocs.sln
+++ b/NaturalDocs.sln
@@ -1,0 +1,31 @@
+﻿
+Microsoft Visual Studio Solution File, Format Version 12.00
+# Visual Studio 15
+VisualStudioVersion = 15.0.27130.2010
+MinimumVisualStudioVersion = 10.0.40219.1
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "CLI", "CLI\CLI.csproj", "{2190235A-96D0-4369-B6E6-4C123B76DA04}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Engine", "Engine\Engine.csproj", "{F7569B05-FFFD-4084-8F33-760F3E1916CD}"
+EndProject
+Global
+	GlobalSection(SolutionConfigurationPlatforms) = preSolution
+		Debug|x86 = Debug|x86
+		Release|x86 = Release|x86
+	EndGlobalSection
+	GlobalSection(ProjectConfigurationPlatforms) = postSolution
+		{2190235A-96D0-4369-B6E6-4C123B76DA04}.Debug|x86.ActiveCfg = Debug|x86
+		{2190235A-96D0-4369-B6E6-4C123B76DA04}.Debug|x86.Build.0 = Debug|x86
+		{2190235A-96D0-4369-B6E6-4C123B76DA04}.Release|x86.ActiveCfg = Release|x86
+		{2190235A-96D0-4369-B6E6-4C123B76DA04}.Release|x86.Build.0 = Release|x86
+		{F7569B05-FFFD-4084-8F33-760F3E1916CD}.Debug|x86.ActiveCfg = Debug|x86
+		{F7569B05-FFFD-4084-8F33-760F3E1916CD}.Debug|x86.Build.0 = Debug|x86
+		{F7569B05-FFFD-4084-8F33-760F3E1916CD}.Release|x86.ActiveCfg = Release|x86
+		{F7569B05-FFFD-4084-8F33-760F3E1916CD}.Release|x86.Build.0 = Release|x86
+	EndGlobalSection
+	GlobalSection(SolutionProperties) = preSolution
+		HideSolutionNode = FALSE
+	EndGlobalSection
+	GlobalSection(ExtensibilityGlobals) = postSolution
+		SolutionGuid = {50747555-C17C-456F-94D5-85A4097246A8}
+	EndGlobalSection
+EndGlobal


### PR DESCRIPTION
Patch to base:master to allow italics and in-line code markup. Italics markup is denoted by placing the text between forward slashes, e.g., this is an /italics/ word, that is rendered as, e.g., this is an *italics* word. In-line Code markup is denoted by placing the text between vertical bars, e.g., this is a |code| variable, that is rendered as, e.g., this is a `code` variable, minus the background highlighting provided by markdown.

References:
Issues #13 Enhancement: support for in-line code markup.
Issues #14 Enhancement: support for italics