### PR TITLE
Automated documentation generation

### DIFF
--- a/.nd_project.txt
+++ b/.nd_project.txt
@@ -1,0 +1,10 @@
+Format: 2.0.2
+Source Folder: ../CLI/Source
+   Name: Command Line Interface
+
+Source Folder: ../Engine/Source
+   Name: Engine
+   
+HTML Output Folder: ../docs
+
+Title: NaturalDocs

--- a/.travis.yml
+++ b/.travis.yml
@@ -9,19 +9,13 @@ before_script:
   - cp .nd_project.txt $TRAVIS_BUILD_DIR/.ND_Config/Project.txt
 script:
   - echo '#!/bin/bash' > ./xcopy
-  - echo 'cp -r $1 $2' >> ./xcopy
-  - sudo chmod 777 ./xcopy
+  - echo "string2='/*'" >> ./xcopy
+  - echo 'cp -r $1$string2 $2' >> ./xcopy
+  - sudo chmod '+x' ./xcopy
   - sudo mv ./xcopy /bin
   - msbuild /p:Configuration=Release CLI/CLI.csproj
   - msbuild /p:Configuration=Release Engine.Tests/Engine.Tests.csproj
-  - cp -r Engine/Resources/Translations Engine.Tests/bin/Release/
-  - cp -r Engine/Resources/Config Engine.Tests/bin/Release/
-  - cp -r Engine/Resources/Styles Engine.Tests/bin/Release/
   - mono ./testrunner/NUnit.ConsoleRunner.3.9.0/tools/nunit3-console.exe ./Engine.Tests/bin/Release/NaturalDocs.Engine.Tests.dll
-  - cp -r CLI/Resources/Translations CLI/bin/Release/
-  - cp Engine/Resources/Translations/* CLI/bin/Release/Translations/
-  - cp -r Engine/Resources/Config CLI/bin/Release/
-  - cp -r Engine/Resources/Styles CLI/bin/Release/
   - mono CLI/bin/Release/NaturalDocs.exe $TRAVIS_BUILD_DIR/.ND_Config
 deploy:
   provider: pages

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,32 @@
+language: csharp
+mono:
+  - latest
+install:
+  - nuget install NUnit.Console -Version 3.9.0 -OutputDirectory testrunner
+before_script:
+  - mkdir $TRAVIS_BUILD_DIR/docs
+  - mkdir $TRAVIS_BUILD_DIR/.ND_Config
+  - cp .nd_project.txt $TRAVIS_BUILD_DIR/.ND_Config/Project.txt
+script:
+  - echo '#!/bin/bash' > ./xcopy
+  - echo 'cp -r $1 $2' >> ./xcopy
+  - sudo chmod 777 ./xcopy
+  - sudo mv ./xcopy /bin
+  - msbuild /p:Configuration=Release CLI/CLI.csproj
+  - msbuild /p:Configuration=Release Engine.Tests/Engine.Tests.csproj
+  - cp -r Engine/Resources/Translations Engine.Tests/bin/Release/
+  - cp -r Engine/Resources/Config Engine.Tests/bin/Release/
+  - cp -r Engine/Resources/Styles Engine.Tests/bin/Release/
+  - mono ./testrunner/NUnit.ConsoleRunner.3.9.0/tools/nunit3-console.exe ./Engine.Tests/bin/Release/NaturalDocs.Engine.Tests.dll
+  - cp -r CLI/Resources/Translations CLI/bin/Release/
+  - cp Engine/Resources/Translations/* CLI/bin/Release/Translations/
+  - cp -r Engine/Resources/Config CLI/bin/Release/
+  - cp -r Engine/Resources/Styles CLI/bin/Release/
+  - mono CLI/bin/Release/NaturalDocs.exe $TRAVIS_BUILD_DIR/.ND_Config
+deploy:
+  provider: pages
+  skip_cleanup: true
+  local_dir: $TRAVIS_BUILD_DIR/docs
+  github_token: $GH_REPO_TOKEN
+  on:
+    branch: Docs

--- a/.travis.yml
+++ b/.travis.yml
@@ -29,4 +29,4 @@ deploy:
   local_dir: $TRAVIS_BUILD_DIR/docs
   github_token: $GH_REPO_TOKEN
   on:
-    branch: Docs
+    branch: master

--- a/README.md
+++ b/README.md
@@ -1,3 +1,5 @@
+[![Build Status](https://travis-ci.org/NaturalDocs/NaturalDocs.svg?branch=master)](https://travis-ci.org/NaturalDocs/NaturalDocs)
+
 # Natural Docs
 
 Natural Docs is an open source documentation generator for 


### PR DESCRIPTION
This patch builds on the the CI patch. Travis-CI will build and test the code, then use the newly compiled binary to generate project documentation and push to the gh-pages branch. Before merging this branch, a gh-pages branch will need to be created, and travis-ci will have to be given access to the repository with a token. Instructions are in the reddit post.

I was surprised to see that a source code documentation program did not show off its own documentation. This patch closes that loop. The only thing missing is a link from the README.md file to the new page. 