### PR TITLE
Code coverage

### DIFF
--- a/.nd_project.txt
+++ b/.nd_project.txt
@@ -1,0 +1,10 @@
+Format: 2.0.2
+Source Folder: ../CLI/Source
+   Name: Command Line Interface
+
+Source Folder: ../Engine/Source
+   Name: Engine
+   
+HTML Output Folder: ../docs
+
+Title: NaturalDocs

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,32 @@
+language: csharp
+mono:
+  - latest
+install:
+  - nuget install NUnit.Console -Version 3.9.0 -OutputDirectory testrunner
+before_script:
+  - mkdir $TRAVIS_BUILD_DIR/docs
+  - mkdir $TRAVIS_BUILD_DIR/.ND_Config
+  - cp .nd_project.txt $TRAVIS_BUILD_DIR/.ND_Config/Project.txt
+script:
+  - echo '#!/bin/bash' > ./xcopy
+  - echo 'cp -r $1 $2' >> ./xcopy
+  - sudo chmod 777 ./xcopy
+  - sudo mv ./xcopy /bin
+  - msbuild /p:Configuration=Release CLI/CLI.csproj
+  - msbuild /p:Configuration=Release Engine.Tests/Engine.Tests.csproj
+  - cp -r Engine/Resources/Translations Engine.Tests/bin/Release/
+  - cp -r Engine/Resources/Config Engine.Tests/bin/Release/
+  - cp -r Engine/Resources/Styles Engine.Tests/bin/Release/
+  - mono ./testrunner/NUnit.ConsoleRunner.3.9.0/tools/nunit3-console.exe ./Engine.Tests/bin/Release/NaturalDocs.Engine.Tests.dll
+  - cp -r CLI/Resources/Translations CLI/bin/Release/
+  - cp Engine/Resources/Translations/* CLI/bin/Release/Translations/
+  - cp -r Engine/Resources/Config CLI/bin/Release/
+  - cp -r Engine/Resources/Styles CLI/bin/Release/
+  - mono CLI/bin/Release/NaturalDocs.exe $TRAVIS_BUILD_DIR/.ND_Config
+deploy:
+  provider: pages
+  skip_cleanup: true
+  local_dir: $TRAVIS_BUILD_DIR/docs
+  github_token: $GH_REPO_TOKEN
+  on:
+    branch: Docs

--- a/.travis.yml
+++ b/.travis.yml
@@ -29,4 +29,4 @@ deploy:
   local_dir: $TRAVIS_BUILD_DIR/docs
   github_token: $GH_REPO_TOKEN
   on:
-    branch: Docs
+    branch: master

--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 [![Build Status](https://travis-ci.org/NaturalDocs/NaturalDocs.svg?branch=master)](https://travis-ci.org/NaturalDocs/NaturalDocs)
-
+[![Build status](https://ci.appveyor.com/api/projects/status/pm53j27386wap25d/branch/master?svg=true)](https://ci.appveyor.com/project/NaturalDocs/naturaldocs/branch/master)
 # Natural Docs
 
 Natural Docs is an open source documentation generator for 

--- a/README.md
+++ b/README.md
@@ -1,3 +1,5 @@
+[![Build Status](https://travis-ci.org/NaturalDocs/NaturalDocs.svg?branch=master)](https://travis-ci.org/NaturalDocs/NaturalDocs)
+
 # Natural Docs
 
 Natural Docs is an open source documentation generator for 

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,0 +1,7 @@
+version: 0.0.{build}
+image: 
+  - Visual Studio 2017
+environment:
+  DOTNET_SKIP_FIRST_TIME_EXPERIENCE: true
+build:
+  project: CLI/CLI.csproj

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -7,4 +7,4 @@ build:
   project: Engine.Tests/Engine.Tests.csproj
 test:
   assemblies:
-    - ./Engine.Tests/bin/Release/NaturalDocs.Engine.Tests.dll
+    - ./Engine.Tests/bin/Debug/NaturalDocs.Engine.Tests.dll

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -5,8 +5,13 @@ environment:
   matrix:
     - NaturalDocsProj: Engine.Tests/Engine.Tests.csproj
     - NaturalDocsProj: CLI/CLI.csproj
+before_build:
+  - nuget restore Engine.Tests/Engine.Tests.csproj
+  - choco install opencover.portable
+  - choco install codecov
 build:
   project: $(NaturalDocsProj)
-test:
-  assemblies:
-    - ./Engine.Tests/bin/Debug/NaturalDocs.Engine.Tests.dll
+  verbosity: minimal
+test_script:
+  - OpenCover.Console.exe -register:user -target:"nunit-console-x86.exe" -targetargs:".\Engine.Tests\bin\Debug\NaturalDocs.Engine.Tests.dll" -output:".\MyProject_coverage.xml"
+  - codecov -f "MyProject_coverage.xml

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -3,9 +3,9 @@ image:
   - Visual Studio 2017
 environment:
   DOTNET_SKIP_FIRST_TIME_EXPERIENCE: true
- matrix: 
-      - NaturalDocs: CLI/CLI.csproj 
-      - NaturalDocs: Engine.Tests/Engine.Tests.csproj
+matrix:
+  - NaturalDocs: CLI/CLI.csproj
+  - NaturalDocs: Engine.Tests/Engine.Tests.csproj
 build:
   project: $(NaturalDocs)
 test:

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -3,8 +3,11 @@ image:
   - Visual Studio 2017
 environment:
   DOTNET_SKIP_FIRST_TIME_EXPERIENCE: true
+ matrix: 
+      - NaturalDocs: CLI/CLI.csproj 
+      - NaturalDocs: Engine.Tests/Engine.Tests.csproj
 build:
-  project: CLI/CLI.csproj
+  project: $(NaturalDocs)
 test:
   assemblies:
     - ./Engine.Tests/bin/Release/NaturalDocs.Engine.Tests.dll

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -3,11 +3,8 @@ image:
   - Visual Studio 2017
 environment:
   DOTNET_SKIP_FIRST_TIME_EXPERIENCE: true
-matrix:
-  - NaturalDocs: CLI/CLI.csproj
-  - NaturalDocs: Engine.Tests/Engine.Tests.csproj
 build:
-  project: $(NaturalDocs)
+  project: Engine.Tests/Engine.Tests.csproj
 test:
   assemblies:
     - ./Engine.Tests/bin/Release/NaturalDocs.Engine.Tests.dll

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -2,9 +2,11 @@ version: 0.0.{build}
 image: 
   - Visual Studio 2017
 environment:
-  DOTNET_SKIP_FIRST_TIME_EXPERIENCE: true
+  matrix:
+    - NaturalDocsProj: Engine.Tests/Engine.Tests.csproj
+    - NaturalDocsProj: CLI/CLI.csproj
 build:
-  project: Engine.Tests/Engine.Tests.csproj
+  project: $(NaturalDocsProj)
 test:
   assemblies:
     - ./Engine.Tests/bin/Debug/NaturalDocs.Engine.Tests.dll

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -6,3 +6,6 @@ environment:
   DOTNET_SKIP_FIRST_TIME_EXPERIENCE: true
 build:
   project: CLI/CLI.csproj
+test:
+  assemblies:
+    - ./Engine.Tests/bin/Release/NaturalDocs.Engine.Tests.dll

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,7 +1,6 @@
 version: 0.0.{build}
 image: 
   - Visual Studio 2017
-  - ubuntu
 environment:
   DOTNET_SKIP_FIRST_TIME_EXPERIENCE: true
 build:

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,6 +1,7 @@
 version: 0.0.{build}
 image: 
   - Visual Studio 2017
+  - ubuntu
 environment:
   DOTNET_SKIP_FIRST_TIME_EXPERIENCE: true
 build:


### PR DESCRIPTION
This pull request builds on the CI patch. It modifies the AppVeyor configuration to include a code coverage report at Codecov.io. Currently, the codebase is at 72% coverage.

https://codecov.io/gh/Beakerboy/NaturalDocs/tree/e5d3f2667cbe606ced334633094fa7f5dcda23e1