### PR TITLE
Add support for Source Folder external URL

### DIFF
--- a/Engine/Source/Config/ConfigFiles/TextFileParser.cs
+++ b/Engine/Source/Config/ConfigFiles/TextFileParser.cs
@@ -240,6 +240,23 @@ namespace CodeClear.NaturalDocs.Engine.Config.ConfigFiles
 				}
 
 
+			else if (lcIdentifier == "url")
+				{
+				 if (inputTarget is Targets.SourceFolder &&
+					(inputTarget as Targets.SourceFolder).Type == Files.InputType.Source)
+					{
+					(inputTarget as Targets.SourceFolder).Url = value;
+					(inputTarget as Targets.SourceFolder).UrlPropertyLocation = propertyLocation;
+					}
+				else
+					{
+					errorList.Add( Locale.Get("NaturalDocs.Engine", "Project.txt.UrlOnlyAppliesToSourceFolders"),
+									   propertyLocation.FileName, propertyLocation.LineNumber );
+					}
+
+				return true;
+				}
+
 			// Encoding
 
 			else if (encodingRegex.IsMatch(lcIdentifier))
@@ -942,6 +959,10 @@ namespace CodeClear.NaturalDocs.Engine.Config.ConfigFiles
 			bool hasName = (target.NamePropertyLocation.IsDefined &&
 									 target.NamePropertyLocation.Source != PropertySource.SystemDefault);
 
+
+			bool hasUrl = (target.UrlPropertyLocation.IsDefined &&
+									 target.UrlPropertyLocation.Source != PropertySource.SystemDefault);
+
 			int encodingRules = 0;
 			if (projectConfig.InputSettings.HasCharacterEncodingRules)
 				{
@@ -970,7 +991,10 @@ namespace CodeClear.NaturalDocs.Engine.Config.ConfigFiles
 			if (hasName)
 				{  output.AppendLine("   Name: " + target.Name);  }
 
-			if (hasName && encodingRules > 1)
+			if (hasUrl)
+				{  output.AppendLine("   Url: " + target.Url);  }
+
+			if ((hasName||hasUrl) && encodingRules > 1)
 				{  output.AppendLine();  }
 
 			AppendOverriddenInputSettings(target, output);

--- a/Engine/Source/Config/Targets/SourceFolder.cs
+++ b/Engine/Source/Config/Targets/SourceFolder.cs
@@ -28,18 +28,22 @@ namespace CodeClear.NaturalDocs.Engine.Config.Targets
 			{
 			folder = null;
 			name = null;
+			url = null;
 
 			folderPropertyLocation = PropertySource.NotDefined;
 			namePropertyLocation = PropertySource.NotDefined;
+			urlPropertyLocation = PropertySource.NotDefined;
 			}
 
 		public SourceFolder (SourceFolder toCopy) : base (toCopy)
 			{
 			folder = toCopy.folder;
 			name = toCopy.name;
+			url = toCopy.url;
 
 			folderPropertyLocation = toCopy.folderPropertyLocation;
 			namePropertyLocation = toCopy.namePropertyLocation;
+			urlPropertyLocation = toCopy.urlPropertyLocation;
 			}
 
 		override public Input Duplicate ()
@@ -149,6 +153,16 @@ namespace CodeClear.NaturalDocs.Engine.Config.Targets
 				{  name = value;  }
 			}
 
+		/* Property: Url
+		 * 
+		 */
+		public string Url
+			{
+			get
+				{  return url;  }
+			set
+				{  url = value;  }
+			}
 
 
 		// Group: Property Locations
@@ -178,6 +192,16 @@ namespace CodeClear.NaturalDocs.Engine.Config.Targets
 		        {  namePropertyLocation = value;  }
 		    }
 
+		/* Property: UrlPropertyLocation
+		 * Where <Url> is defined, or <PropertySource.NotDefined> if it isn't.
+		 */
+		public PropertyLocation UrlPropertyLocation
+		    {
+		    get
+		        {  return urlPropertyLocation;  }
+		    set
+		        {  urlPropertyLocation = value;  }
+		    }
 
 
 		// Group: Variables
@@ -186,9 +210,11 @@ namespace CodeClear.NaturalDocs.Engine.Config.Targets
 
 		protected AbsolutePath folder;
 		protected string name;
+		protected string url;
 
 		protected PropertyLocation folderPropertyLocation;
 		protected PropertyLocation namePropertyLocation;
+		protected PropertyLocation urlPropertyLocation;
 
 		}
 	}

--- a/Engine/Source/Files/FileSources/SourceFolder.cs
+++ b/Engine/Source/Files/FileSources/SourceFolder.cs
@@ -137,6 +137,15 @@ namespace CodeClear.NaturalDocs.Engine.Files.FileSources
 			}
 
 
+		/* Property: Url
+		 * The url of the FileSource's folder.
+		 */
+		public string Url
+			{
+			get
+				{  return config.Url;  }
+			}
+
 
 		// Group: Variables
 		// __________________________________________________________________________

--- a/Engine/Source/Output/HTML/Components/Topic.cs
+++ b/Engine/Source/Output/HTML/Components/Topic.cs
@@ -22,6 +22,7 @@ using System.Text;
 using CodeClear.NaturalDocs.Engine.Links;
 using CodeClear.NaturalDocs.Engine.Prototypes;
 using CodeClear.NaturalDocs.Engine.Tokenization;
+using CodeClear.NaturalDocs.Engine.Files;
 
 
 namespace CodeClear.NaturalDocs.Engine.Output.HTML.Components
@@ -188,8 +189,18 @@ namespace CodeClear.NaturalDocs.Engine.Output.HTML.Components
 			else
 				{  mode = WrappedTitleMode.None;  }
 
+			File file = EngineInstance.Files.FromID(context.Topic.FileID);
+			var fileSource = EngineInstance.Files.FileSourceOf(file);
+			string fileUrl = (fileSource as Files.FileSources.SourceFolder).Url;
+			string filePath = fileSource.MakeRelative(file.FileName);
+			int lineNum = context.Topic.CommentLineNumber;
+
 			output.Append("<div class=\"CTitle\">");
 			AppendWrappedTitle(context.Topic.Title, mode, output);
+			if (fileUrl != null && lineNum != 0) {
+				string url = fileUrl.Replace("{filePath}", filePath).Replace("{lineNum}", lineNum.ToString());
+				output.Append("<a class=\"ExternalFileUrl\" target=\"_blank\" href=\""+url+"\">🡕</a>");
+			}
 			output.Append("</div>");
 			}
 


### PR DESCRIPTION
I know this feature pull request is probably incomplete. Creating it to get feedback

This pull request creates a feature where each Source Folder can have an external URL attached, which can be used to generate a link to the source code of a definition in the documentation. Example

```
Source Folder: docs/uvm-src
   Name: UVM 1.2
   Url: https://github.com/accellera/uvm/blob/UVM_1_2_RELEASE/distrib/src/{filePath}#L{lineNum}

```

- Can this feature be added?
- What should I fix/improve to complete it?