### PR TITLE
Option 'Document Privates' added

### DIFF
--- a/CLI/Source/Application.CommandLine.cs
+++ b/CLI/Source/Application.CommandLine.cs
@@ -506,6 +506,23 @@ namespace CodeClear.NaturalDocs.CLI
 						}
 					}
 
+				// Document privates:
+				else if (parameter == "--document-privates")
+					{
+					if (!commandLine.NoValue())
+						{
+						errorList.Add(
+							Locale.Get("NaturalDocs.CLI", "CommandLine.ExpectedNoValue(param)", parameterAsEntered)
+						);
+						commandLine.SkipToNextParameter();
+						}
+					else
+						{
+						commandLineConfig.DocumentPrivates = true;
+						commandLineConfig.DocumentPrivatesPropertyLocation = PropertySource.CommandLine;
+						}
+				}
+
 
 
 				// No Auto-Group

--- a/Engine.Tests.Runner/Source/Runner.cs
+++ b/Engine.Tests.Runner/Source/Runner.cs
@@ -116,7 +116,7 @@ namespace CodeClear.NaturalDocs.Engine.Tests
 
 				int foundFailures = 0;
 				StringBuilder failures = new StringBuilder();
-				MatchCollection failureMatches = Regex.Matches(xmlContent, @"<failure>.*?<message><!\[CDATA\[(.*?)\]\]>.*?</message>.*?</failure>", RegexOptions.Singleline);
+				MatchCollection failureMatches = System.Text.RegularExpressions.Regex.Matches(xmlContent, @"<failure>.*?<message><!\[CDATA\[(.*?)\]\]>.*?</message>.*?</failure>", RegexOptions.Singleline);
 
 				foreach (Match failureMatch in failureMatches)
 					{

--- a/Engine.Tests/Source/Framework/SourceToHTML.cs
+++ b/Engine.Tests/Source/Framework/SourceToHTML.cs
@@ -378,9 +378,9 @@ namespace CodeClear.NaturalDocs.Engine.Tests.Framework
 		// Group: Static Variables
 		// __________________________________________________________________________
 
-		static protected Regex TagsToFormatRegex = new Regex("(?:</?div[^>]*>|-----\r\n)",
+		static protected System.Text.RegularExpressions.Regex TagsToFormatRegex = new System.Text.RegularExpressions.Regex("(?:</?div[^>]*>|-----\r\n)",
 																						 RegexOptions.Compiled | RegexOptions.Singleline | RegexOptions.CultureInvariant);
-		static protected Regex IDNumbersRegex = new Regex(" id=\"ND(?:Class)?Prototype[0-9]+\"",
+		static protected System.Text.RegularExpressions.Regex IDNumbersRegex = new System.Text.RegularExpressions.Regex(" id=\"ND(?:Class)?Prototype[0-9]+\"",
 																					   RegexOptions.Compiled | RegexOptions.Singleline | RegexOptions.CultureInvariant);
 
 		}

--- a/Engine.Tests/Source/Framework/TestTypes/JavadocIterator.cs
+++ b/Engine.Tests/Source/Framework/TestTypes/JavadocIterator.cs
@@ -130,7 +130,7 @@ namespace CodeClear.NaturalDocs.Engine.Tests.Framework.TestTypes
 			return output.ToString();
 			}
 
-		static private Regex FindPropertyRegex = new Regex(" *Property ([a-z\\-_]+) in (.*)$",
+		static private System.Text.RegularExpressions.Regex FindPropertyRegex = new System.Text.RegularExpressions.Regex(" *Property ([a-z\\-_]+) in (.*)$",
 																					 RegexOptions.Compiled | RegexOptions.IgnoreCase | RegexOptions.CultureInvariant);
 
 		}

--- a/Engine.Tests/Source/Framework/TestTypes/LinkScoring.cs
+++ b/Engine.Tests/Source/Framework/TestTypes/LinkScoring.cs
@@ -637,11 +637,11 @@ namespace CodeClear.NaturalDocs.Engine.Tests.Framework.TestTypes
 			return output.ToString();
 			}
 
-		protected static Regex GetPropertyRegex = new Regex(@"^[ \t]*(Topic|Link)\.([a-z]+)[ \t]*=[ \t]*(null|"".*"")[ \t]*$",
+		protected static System.Text.RegularExpressions.Regex GetPropertyRegex = new System.Text.RegularExpressions.Regex(@"^[ \t]*(Topic|Link)\.([a-z]+)[ \t]*=[ \t]*(null|"".*"")[ \t]*$",
 																				  RegexOptions.Compiled | RegexOptions.Singleline | RegexOptions.IgnoreCase | RegexOptions.CultureInvariant);
-		protected static Regex AddPrefixRegex = new Regex(@"^[ \t]*Link\.Using[ \t]*(\+?=)[ \t]*Add Prefix ""(.*)""[ \t]*$",
+		protected static System.Text.RegularExpressions.Regex AddPrefixRegex = new System.Text.RegularExpressions.Regex(@"^[ \t]*Link\.Using[ \t]*(\+?=)[ \t]*Add Prefix ""(.*)""[ \t]*$",
 																			  RegexOptions.Compiled | RegexOptions.Singleline | RegexOptions.IgnoreCase | RegexOptions.CultureInvariant);
-		protected static Regex ReplacePrefixRegex = new Regex(@"^[ \t]*Link\.Using[ \t]*(\+?=)[ \t]*Replace Prefix ""(.*)"" with ""(.*)""[ \t]*$",
+		protected static System.Text.RegularExpressions.Regex ReplacePrefixRegex = new System.Text.RegularExpressions.Regex(@"^[ \t]*Link\.Using[ \t]*(\+?=)[ \t]*Replace Prefix ""(.*)"" with ""(.*)""[ \t]*$",
 																					RegexOptions.Compiled | RegexOptions.Singleline | RegexOptions.IgnoreCase | RegexOptions.CultureInvariant);
 
 		}

--- a/Engine.Tests/Source/Framework/TestTypes/NumberSet.cs
+++ b/Engine.Tests/Source/Framework/TestTypes/NumberSet.cs
@@ -143,11 +143,11 @@ namespace CodeClear.NaturalDocs.Engine.Tests.Framework.TestTypes
 			return output.ToString();
 			}
 
-		protected static Regex GetBracesRegex = new Regex(@"{.*?}",
+		protected static System.Text.RegularExpressions.Regex GetBracesRegex = new System.Text.RegularExpressions.Regex(@"{.*?}",
 																					 RegexOptions.Compiled | RegexOptions.Singleline | RegexOptions.CultureInvariant);
-		protected static Regex GetNumberRegex = new Regex("[0-9]+",
+		protected static System.Text.RegularExpressions.Regex GetNumberRegex = new System.Text.RegularExpressions.Regex("[0-9]+",
 																					   RegexOptions.Compiled | RegexOptions.Singleline | RegexOptions.CultureInvariant);
-		protected static Regex ExtractRangeRegex = new Regex("Extract ([0-9]+), ?([0-9]+)",
+		protected static System.Text.RegularExpressions.Regex ExtractRangeRegex = new System.Text.RegularExpressions.Regex("Extract ([0-9]+), ?([0-9]+)",
 																						 RegexOptions.Compiled | RegexOptions.Singleline | RegexOptions.IgnoreCase | RegexOptions.CultureInvariant);
 
 		}

--- a/Engine.Tests/Source/Framework/TestTypes/XMLIterator.cs
+++ b/Engine.Tests/Source/Framework/TestTypes/XMLIterator.cs
@@ -117,7 +117,7 @@ namespace CodeClear.NaturalDocs.Engine.Tests.Framework.TestTypes
 			return output.ToString();
 			}
 
-		static private Regex FindPropertyRegex = new Regex(" *Property ([a-z\\-_]+) in (.*)$",
+		static private System.Text.RegularExpressions.Regex FindPropertyRegex = new System.Text.RegularExpressions.Regex(" *Property ([a-z\\-_]+) in (.*)$",
 																					 RegexOptions.Compiled | RegexOptions.IgnoreCase | RegexOptions.CultureInvariant);
 
 		}

--- a/Engine/Architecture/File Formats/Project.txt.txt
+++ b/Engine/Architecture/File Formats/Project.txt.txt
@@ -144,6 +144,10 @@ _______________________________________________________________________________
 
 		Whether only documented code elements should appear in the output.
 
+		> Document Privates: [yes|no]
+
+		Whether only public code elements should appear in the output.
+
 		> Auto Group: [yes|no]
 
 		Whether automatic grouping should be applied.

--- a/Engine/DocumentPrivates/DocumentPrivates.cs
+++ b/Engine/DocumentPrivates/DocumentPrivates.cs
@@ -1,0 +1,126 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+
+using System.Text.RegularExpressions;
+
+namespace CodeClear.NaturalDocs.Engine.Regex.Config;
+
+public class DocumentPrivates : System.Text.RegularExpressions.Regex {
+	public DocumentPrivates() {
+		//Error decoding local variables: Signature type sequence must have at least one element.
+		pattern = "^(?:document[ -]privates|privates[ -]document)$";
+		roptions = RegexOptions.Singleline | RegexOptions.CultureInvariant;
+		factory = new DocumentPrivatesFactory411();
+		capsize = 1;
+		InitializeReferences();
+	}
+}
+
+internal class DocumentPrivatesFactory411 : RegexRunnerFactory {
+	protected override RegexRunner CreateInstance() {
+		//Error decoding local variables: Signature type sequence must have at least one element.
+		return new DocumentPrivatesRunner411();
+	}
+}
+
+internal class DocumentPrivatesRunner411 : RegexRunner {
+	protected override void Go() {
+		string text = runtext;
+		int num = runtextstart;
+		int num2 = runtextbeg;
+		int num3 = runtextend;
+		int num4 = runtextpos;
+		int[] array = runtrack;
+		int num5 = runtrackpos;
+		int[] array2 = runstack;
+		int num6 = runstackpos;
+		array[--num5] = num4;
+		array[--num5] = 0;
+		array2[--num6] = num4;
+		array[--num5] = 1;
+		if(num4 <= num2) {
+			array[--num5] = num4;
+			array[--num5] = 2;
+			if(8 <= num3 - num4 && text[num4] == 'd' && text[num4 + 1] == 'o' && text[num4 + 2] == 'c' && text[num4 + 3] == 'u' && text[num4 + 4] == 'm' && text[num4 + 5] == 'e' && text[num4 + 6] == 'n' && text[num4 + 7] == 't' 
+				/*&& text[num4 + 8] == 'e' && text[num4 + 9] == 'd'*/) {
+				num4 += 8;
+				if(num4 < num3 && RegexRunner.CharInClass(text[num4++], "\0\u0004\0 !-.") && 8 <= num3 - num4 && text[num4] == 'p' && text[num4 + 1] == 'r' && text[num4 + 2] == 'i' && text[num4 + 3] == 'v' && text[num4 + 4] == 'a' && text[num4 + 5] == 't' && text[num4 + 6] == 'e' && text[num4 + 7] == 's') {
+					num4 += 8;
+					goto IL_0340;
+				}
+			}
+		}
+
+		goto IL_039b;
+IL_0392:
+		runtextpos = num4;
+		return;
+IL_0339:
+		num4 += 8;
+		goto IL_0340;
+IL_0340:
+		if(num4 >= num3 - 1 && (num4 >= num3 || text[num4] == '\n')) {
+			int num7 = array2[num6++];
+			Capture(0, num7, num4);
+			array[--num5] = num7;
+			array[--num5] = 3;
+			goto IL_0392;
+		}
+
+		goto IL_039b;
+IL_039b:
+		while(true) {
+			runtrackpos = num5;
+			runstackpos = num6;
+			EnsureStorage();
+			num5 = runtrackpos;
+			num6 = runstackpos;
+			array = runtrack;
+			array2 = runstack;
+			switch(array[num5++]) {
+				case 1:
+					num6++;
+					continue;
+				case 2:
+					goto IL_040d;
+				case 3:
+					array2[--num6] = array[num5++];
+					Uncapture();
+					continue;
+			}
+
+			break;
+IL_040d:
+			num4 = array[num5++];
+			if(8 > num3 - num4 || text[num4] != 'p' || text[num4 + 1] != 'r' || text[num4 + 2] != 'i' || text[num4 + 3] != 'v'|| text[num4 + 4] != 'a'|| text[num4 + 5] != 't'|| text[num4 + 6] != 'e'|| text[num4 + 7] != 's') {
+				continue;
+			}
+
+			num4 += 8;
+			if(num4 >= num3 || !RegexRunner.CharInClass(text[num4++], "\0\u0004\0 !-.") || 8>num3-num4 || text[num4]!='d' || text[num4 + 1]!='o' || text[num4 + 2]!='c' || text[num4 + 3]!='u' || text[num4 + 4]!='m' || text[num4 + 5]!='e' || text[num4 + 6]!='n' || text[num4 + 7]!='t') {
+				continue;
+			}
+
+			goto IL_0339;
+		}
+
+		num4 = array[num5++];
+		goto IL_0392;
+	}
+
+	protected override bool FindFirstChar() {
+		if(runtextpos > runtextbeg) {
+			runtextpos = runtextend;
+			return false;
+		}
+
+		return true;
+	}
+
+	protected override void InitTrackCount() {
+		//Error decoding local variables: Signature type sequence must have at least one element.
+		runtrackcount = 5;
+	}
+}

--- a/Engine/Engine.csproj
+++ b/Engine/Engine.csproj
@@ -47,6 +47,7 @@
     <RunPostBuildEvent>Always</RunPostBuildEvent>
   </PropertyGroup>
   <ItemGroup>
+    <Compile Include="DocumentPrivates\DocumentPrivates.cs" />
     <Compile Include="Source\Comments\NaturalDocs\Config.cs" />
     <Compile Include="Source\Comments\NaturalDocs\ConfigFiles\BinaryFileParser.cs" />
     <Compile Include="Source\Comments\NaturalDocs\ConfigFiles\TextFileParser.cs" />

--- a/Engine/Resources/Translations/NaturalDocs.Engine.default.txt
+++ b/Engine/Resources/Translations/NaturalDocs.Engine.default.txt
@@ -415,6 +415,12 @@ Project.txt.DocumentedOnlySyntax.multiline {{{
 #    Defaults to no.
 }}}
 
+Project.txt.DocumentPrivatesSyntax.multiline {{{
+# Document Privates: [yes|no]
+#    Whether only public code elements should appear in the output.
+#    Defaults to yes.
+}}}
+
 Project.txt.AutoGroupSyntax.multiline {{{
 # Auto Group: [yes|no]
 #    Whether groups should automatically apply to you code.  Defaults to yes.

--- a/Engine/Source/Config/ConfigFiles/BinaryFileParser.cs
+++ b/Engine/Source/Config/ConfigFiles/BinaryFileParser.cs
@@ -85,6 +85,8 @@ namespace CodeClear.NaturalDocs.Engine.Config.ConfigFiles
 					projectConfig.ShrinkFiles = (binaryFile.ReadByte() == 1);
 					projectConfig.ShrinkFilesPropertyLocation = PropertySource.PreviousRun;
 
+					projectConfig.DocumentPrivates = (binaryFile.ReadByte() == 1);
+					projectConfig.DocumentPrivatesPropertyLocation = PropertySource.PreviousRun;
 					// [String: Identifier]
 					// [[Properties]]
 					// ...
@@ -211,6 +213,7 @@ namespace CodeClear.NaturalDocs.Engine.Config.ConfigFiles
 		        binaryFile.WriteByte( (byte)((bool)projectConfig.DocumentedOnly == false ? 0 : 1) );
 		        binaryFile.WriteByte( (byte)((bool)projectConfig.AutoGroup == false ? 0 : 1) );
 		        binaryFile.WriteByte( (byte)((bool)projectConfig.ShrinkFiles == false ? 0 : 1) );
+		        binaryFile.WriteByte( (byte)((bool)projectConfig.DocumentPrivates == false ? 0 : 1) );
 
 		        // [String: Identifier]
 		        // [[Properties]]

--- a/Engine/Source/Config/ConfigFiles/TextFileParser.cs
+++ b/Engine/Source/Config/ConfigFiles/TextFileParser.cs
@@ -47,6 +47,7 @@ namespace CodeClear.NaturalDocs.Engine.Config.ConfigFiles
 			tabWidthRegex = new Regex.Config.TabWidth();
 			documentedOnlyRegex = new Regex.Config.DocumentedOnly();
 			autoGroupRegex = new Regex.Config.AutoGroup();
+			documentPrivatesRegex = new Regex.Config.DocumentPrivates();
 
 			sourceFolderRegex = new Regex.Config.SourceFolder();
 			imageFolderRegex = new Regex.Config.ImageFolder();
@@ -629,6 +630,25 @@ namespace CodeClear.NaturalDocs.Engine.Config.ConfigFiles
 
 				return true;
 				}
+
+			// Document Privates
+			else if (documentPrivatesRegex.IsMatch(lcIdentifier))
+			{
+				if (yesRegex.IsMatch(value))
+				{
+					projectConfig.DocumentPrivates = true;
+					projectConfig.DocumentPrivatesPropertyLocation = propertyLocation;
+				}
+				else if (noRegex.IsMatch(value))
+				{
+					projectConfig.DocumentPrivates = false;
+					projectConfig.DocumentPrivatesPropertyLocation = propertyLocation;
+				}
+				else errorList.Add( Locale.Get("NaturalDocs.Engine", "Project.txt.UnrecognizedValue(keyword, value)", "Document Privates", value),
+									   propertyLocation.FileName, propertyLocation.LineNumber );
+
+				return true;
+			}
 
 
 			// Auto-group
@@ -1271,6 +1291,9 @@ namespace CodeClear.NaturalDocs.Engine.Config.ConfigFiles
 			bool hasAutoGroup = (projectConfig.AutoGroupPropertyLocation.IsDefined &&
 										  projectConfig.AutoGroupPropertyLocation.Source != PropertySource.SystemDefault &&
 										  projectConfig.AutoGroupPropertyLocation.Source != PropertySource.CommandLine);
+			bool hasDocumentPrivates = (projectConfig.DocumentPrivatesPropertyLocation.IsDefined &&
+													projectConfig.DocumentPrivatesPropertyLocation.Source != PropertySource.SystemDefault &&
+													projectConfig.DocumentPrivatesPropertyLocation.Source != PropertySource.CommandLine);
 
 			if (hasTabWidth)
 				{
@@ -1281,6 +1304,12 @@ namespace CodeClear.NaturalDocs.Engine.Config.ConfigFiles
 			if (hasDocumentedOnly)
 				{
 				output.Append("Documented Only: " + (projectConfig.DocumentedOnly ? "Yes" : "No"));
+				output.AppendLine();
+				}
+
+			if (hasDocumentPrivates)
+				{
+				output.Append("Document Privates: " + (projectConfig.DocumentPrivates ? "Yes" : "No"));
 				output.AppendLine();
 				}
 
@@ -1339,6 +1368,7 @@ namespace CodeClear.NaturalDocs.Engine.Config.ConfigFiles
 		protected Regex.Config.TabWidth tabWidthRegex;
 		protected Regex.Config.DocumentedOnly documentedOnlyRegex;
 		protected Regex.Config.AutoGroup autoGroupRegex;
+		protected Regex.Config.DocumentPrivates documentPrivatesRegex;
 
 		protected Regex.Config.SourceFolder sourceFolderRegex;
 		protected Regex.Config.ImageFolder imageFolderRegex;

--- a/Engine/Source/Config/Manager.Start.cs
+++ b/Engine/Source/Config/Manager.Start.cs
@@ -390,10 +390,12 @@ namespace CodeClear.NaturalDocs.Engine.Config
 			documentedOnly = combinedConfig.DocumentedOnly;
 			autoGroup = combinedConfig.AutoGroup;
 			shrinkFiles = combinedConfig.ShrinkFiles;
+			documentPrivates = combinedConfig.DocumentPrivates;
 
 			if (previousConfig == null ||
 				tabWidth != previousConfig.TabWidth ||
 				documentedOnly != previousConfig.DocumentedOnly ||
+				documentPrivates != previousConfig.DocumentPrivates ||
 				autoGroup != previousConfig.AutoGroup)
 				{
 				newStartupIssues |= StartupIssues.NeedToReparseAllFiles;
@@ -858,6 +860,12 @@ namespace CodeClear.NaturalDocs.Engine.Config
 				{
 				primaryConfig.DocumentedOnly = secondaryConfig.DocumentedOnly;
 				primaryConfig.DocumentedOnlyPropertyLocation = secondaryConfig.DocumentedOnlyPropertyLocation;
+				}
+
+			if (!primaryConfig.DocumentPrivatesPropertyLocation.IsDefined)
+				{
+				primaryConfig.DocumentPrivates = secondaryConfig.DocumentPrivates;
+				primaryConfig.DocumentPrivatesPropertyLocation = secondaryConfig.DocumentPrivatesPropertyLocation;
 				}
 
 			if (!primaryConfig.AutoGroupPropertyLocation.IsDefined)

--- a/Engine/Source/Config/Manager.cs
+++ b/Engine/Source/Config/Manager.cs
@@ -57,6 +57,9 @@ namespace CodeClear.NaturalDocs.Engine.Config
 			systemDefaultConfig.ShrinkFiles = true;
 			systemDefaultConfig.ShrinkFilesPropertyLocation = PropertySource.SystemDefault;
 
+			systemDefaultConfig.DocumentPrivates = true;
+			systemDefaultConfig.DocumentPrivatesPropertyLocation = PropertySource.SystemDefault;
+
 			systemDefaultConfig.OutputSettings.StyleName = "Default";
 			systemDefaultConfig.OutputSettings.StyleNamePropertyLocation = PropertySource.SystemDefault;
 			}
@@ -71,6 +74,7 @@ namespace CodeClear.NaturalDocs.Engine.Config
 
 			tabWidth = DefaultTabWidth;
 			documentedOnly = false;
+			documentPrivates = true;
 			autoGroup = true;
 			shrinkFiles = true;
 
@@ -210,6 +214,7 @@ namespace CodeClear.NaturalDocs.Engine.Config
 				{  return documentedOnly;  }
 			}
 
+		public bool DocumentPrivates => documentPrivates; 
 
 		/* Property: AutoGroup
 		 * Whether automatic grouping should be applied.
@@ -309,6 +314,11 @@ namespace CodeClear.NaturalDocs.Engine.Config
 		 * Whether only documented code elements should appear in the output.
 		 */
 		protected bool documentedOnly;
+
+		/* var: documentPrivates
+		 * Whether only public code elements should appear in the output.
+		 */
+		protected bool documentPrivates;
 
 		/* var: autoGroup
 		 * Whether automatic grouping should be applied.

--- a/Engine/Source/Config/ProjectConfig.cs
+++ b/Engine/Source/Config/ProjectConfig.cs
@@ -181,7 +181,11 @@ namespace CodeClear.NaturalDocs.Engine.Config
 				{  shrinkFiles = value;  }
 			}
 
-
+		public bool DocumentPrivates
+		{
+			get => documentPrivates;
+			set => documentPrivates = value;  
+		}
 
 		// Group: Property Locations
 		// __________________________________________________________________________
@@ -256,6 +260,8 @@ namespace CodeClear.NaturalDocs.Engine.Config
 				{  shrinkFilesPropertyLocation = value;  }
 			}
 
+		public PropertyLocation DocumentPrivatesPropertyLocation {get; set; }
+
 
 
 		// Group: Variables
@@ -277,6 +283,8 @@ namespace CodeClear.NaturalDocs.Engine.Config
 		protected bool documentedOnly;
 		protected bool autoGroup;
 		protected bool shrinkFiles;
+		protected bool documentPrivates;
+
 
 		protected PropertyLocation projectConfigFolderPropertyLocation;
 		protected PropertyLocation workingDataFolderPropertyLocation;

--- a/Engine/Source/Languages/Parser.cs
+++ b/Engine/Source/Languages/Parser.cs
@@ -272,8 +272,16 @@ namespace CodeClear.NaturalDocs.Engine.Languages
 							{  element.Topic = null;  }
 						}
 					}
-				}
 
+				// Remove code topics if --document-privates is on.  We do this after merging and keep all the original elements so that the
+				// code's effects still apply.
+				if(!EngineInstance.Config.DocumentPrivates) {
+					foreach(var element in elements)
+						if(element.Topic!=null && element.Topic.DeclaredAccessLevel==AccessLevel.Private)
+							element.Topic = null;
+					}
+
+				}
 
 			// If we have basic language support...
 

--- a/NaturalDocs.sln
+++ b/NaturalDocs.sln
@@ -1,0 +1,52 @@
+﻿
+Microsoft Visual Studio Solution File, Format Version 12.00
+# Visual Studio Version 17
+VisualStudioVersion = 17.9.34728.123
+MinimumVisualStudioVersion = 10.0.40219.1
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "CLI", "CLI\CLI.csproj", "{2190235A-96D0-4369-B6E6-4C123B76DA04}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Engine", "Engine\Engine.csproj", "{F7569B05-FFFD-4084-8F33-760F3E1916CD}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Engine.Tests", "Engine.Tests\Engine.Tests.csproj", "{1D2F367F-A491-417F-A66A-76E49DA9BD78}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Engine.Tests.Runner", "Engine.Tests.Runner\Engine.Tests.Runner.csproj", "{5901FC36-606E-4D87-B244-BCD76BD34210}"
+EndProject
+Global
+	GlobalSection(SolutionConfigurationPlatforms) = preSolution
+		Debug Temp|Any CPU = Debug Temp|Any CPU
+		Debug|Any CPU = Debug|Any CPU
+		Release|Any CPU = Release|Any CPU
+	EndGlobalSection
+	GlobalSection(ProjectConfigurationPlatforms) = postSolution
+		{2190235A-96D0-4369-B6E6-4C123B76DA04}.Debug Temp|Any CPU.ActiveCfg = Debug Temp|Any CPU
+		{2190235A-96D0-4369-B6E6-4C123B76DA04}.Debug Temp|Any CPU.Build.0 = Debug Temp|Any CPU
+		{2190235A-96D0-4369-B6E6-4C123B76DA04}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{2190235A-96D0-4369-B6E6-4C123B76DA04}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{2190235A-96D0-4369-B6E6-4C123B76DA04}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{2190235A-96D0-4369-B6E6-4C123B76DA04}.Release|Any CPU.Build.0 = Release|Any CPU
+		{F7569B05-FFFD-4084-8F33-760F3E1916CD}.Debug Temp|Any CPU.ActiveCfg = Debug|Any CPU
+		{F7569B05-FFFD-4084-8F33-760F3E1916CD}.Debug Temp|Any CPU.Build.0 = Debug|Any CPU
+		{F7569B05-FFFD-4084-8F33-760F3E1916CD}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{F7569B05-FFFD-4084-8F33-760F3E1916CD}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{F7569B05-FFFD-4084-8F33-760F3E1916CD}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{F7569B05-FFFD-4084-8F33-760F3E1916CD}.Release|Any CPU.Build.0 = Release|Any CPU
+		{1D2F367F-A491-417F-A66A-76E49DA9BD78}.Debug Temp|Any CPU.ActiveCfg = Debug|Any CPU
+		{1D2F367F-A491-417F-A66A-76E49DA9BD78}.Debug Temp|Any CPU.Build.0 = Debug|Any CPU
+		{1D2F367F-A491-417F-A66A-76E49DA9BD78}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{1D2F367F-A491-417F-A66A-76E49DA9BD78}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{1D2F367F-A491-417F-A66A-76E49DA9BD78}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{1D2F367F-A491-417F-A66A-76E49DA9BD78}.Release|Any CPU.Build.0 = Release|Any CPU
+		{5901FC36-606E-4D87-B244-BCD76BD34210}.Debug Temp|Any CPU.ActiveCfg = Debug|Any CPU
+		{5901FC36-606E-4D87-B244-BCD76BD34210}.Debug Temp|Any CPU.Build.0 = Debug|Any CPU
+		{5901FC36-606E-4D87-B244-BCD76BD34210}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{5901FC36-606E-4D87-B244-BCD76BD34210}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{5901FC36-606E-4D87-B244-BCD76BD34210}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{5901FC36-606E-4D87-B244-BCD76BD34210}.Release|Any CPU.Build.0 = Release|Any CPU
+	EndGlobalSection
+	GlobalSection(SolutionProperties) = preSolution
+		HideSolutionNode = FALSE
+	EndGlobalSection
+	GlobalSection(ExtensibilityGlobals) = postSolution
+		SolutionGuid = {B6B37624-C8A0-443B-AC06-408D68CD43DB}
+	EndGlobalSection
+EndGlobal

--- a/README.md
+++ b/README.md
@@ -22,3 +22,6 @@ You can also join the community:
 
 Natural Docs is licensed under the GNU Affero General Public License, version 3.  See 
 [this page for the full details.](https://www.naturaldocs.org/license/)
+
+Fork-features:
+- Document Privates as option (Config file or parameter)

--- a/README.md
+++ b/README.md
@@ -23,5 +23,5 @@ You can also join the community:
 Natural Docs is licensed under the GNU Affero General Public License, version 3.  See 
 [this page for the full details.](https://www.naturaldocs.org/license/)
 
-Fork-features:
+# Fork-features:
 - Document Privates as option (Config file or parameter)


### PR DESCRIPTION
I have added '**Document Privates**' option to config and parameter, defaulting to Yes.
Now we can filter out private members from the documentation.